### PR TITLE
correct for loop variable

### DIFF
--- a/src/emagpy/Problem.py
+++ b/src/emagpy/Problem.py
@@ -3021,7 +3021,7 @@ class Problem(object):
             # replot the same graph but with corrected EC
             ax.clear()
             ax.plot([vmin, vmax], [vmin, vmax], 'k-', label='1:1')
-            for i, s in enumerate(self.coils):
+            for i, coil in enumerate(self.coils):
                 # obsECaCorr = (obsECa[:,i] - offsets[i])/slopes[i]
                 obsECaCorr = obsECa[:,i] + offsets[i] - (1-slopes[i]) * obsECa[:,i]
                 x, y = obsECaCorr, simECa[:,i]


### PR DESCRIPTION
wrong name in loop, leading to constant label.

This simple correction permits to having a correct in comparison plot when applying the correction. 
The plot from the ERT-calibration notebook thus become: 

![image](https://user-images.githubusercontent.com/45756772/219440083-a5a6d189-22b3-4694-b47e-1796621f81e0.png)

instead of: 
![image](https://user-images.githubusercontent.com/45756772/219440262-bbd969d1-9fc6-4ee2-adfd-48849239adc3.png)
